### PR TITLE
Added clarification for where Luakit's data directory is located.

### DIFF
--- a/docs/modules/adblock.html
+++ b/docs/modules/adblock.html
@@ -513,7 +513,7 @@ what is happening is to set the appropriate log levels to <code>debug</code>:</p
 <h2>Files and Directories</h2>
 
 <ul>
-    <li>All filterlists should be downloaded to the adblock data directory.
+    <li>All filterlists should be downloaded to the adblock data directory (~/.local/share/luakit/adblock)
     By default, this is the <code>adblock</code> sub-directory of the luakit data
     directory. All filterlists must have a filename ending in <code>.txt</code>.</li>
 </ul>

--- a/docs/modules/adblock.html
+++ b/docs/modules/adblock.html
@@ -483,7 +483,7 @@ cosmetic ad blocking (i.e. element hiding with CSS).</p>
 <h2>Usage</h2>
 
 <ul>
-    <li>Add <code>require "adblock"</code> and <code>require "adblock_chrome"</code> to your <code>config.rc</code>.</li>
+    <li>Add <code>require "adblock"</code> and <code>require "adblock_chrome"</code> to your <code>rc.lua</code>.</li>
     <li>Download AdblockPlus-compatible filter lists to the adblock directory.
     Multiple lists are supported.
     EasyList is the most popular Adblock Plus filter list, and can be


### PR DESCRIPTION
I was about to open an issue because I thought that it was in ~/.config/luakit/data/adblock and I was confused as to why the adblocker wasn't working. I saw in rc.lua that the cookies are stored in the data folder so I just did a find of that.