### PR TITLE
fix the arch linux package link pointing to the old and deprecated community repo and move it to the extra repo url

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
 		<div class="container">
 			<h3>Installing on Linux</h3>
 			<ul>
-				<li><p>Arch Linux users can install the <a href="https://archlinux.org/packages/community/x86_64/luakit/">luakit</a> community package or the
+				<li><p>Arch Linux users can install the <a href="https://archlinux.org/packages/extra/x86_64/luakit/">luakit</a> package or the
 					<a href="https://aur.archlinux.org/packages/luakit-git/" target="_blank">luakit-git</a> package from the AUR.
 				<li><p>Other users will need to download and build from source. A Debian package is in the works. Luakit contains only around 9000 lines of code, so this process is usually very fast.
 			</ul>


### PR DESCRIPTION
update the arch package link